### PR TITLE
knitr no longer supports \SweaveOpts{}

### DIFF
--- a/pkg/vignettes/getting_started.Rnw
+++ b/pkg/vignettes/getting_started.Rnw
@@ -32,7 +32,6 @@
 
 
 \begin{document}
-\SweaveOpts{concordance=TRUE}
 <<setup, include=FALSE, cache=FALSE>>=
 library(knitr)
 opts_chunk$set(size='small')


### PR DESCRIPTION
in your case, `\SweaveOpts{concordance=TRUE}` is not parsed by `knitr`, and it is also the wrong way to use concordance in knitr; the correct way is:

``` r
opts_knit$set(concordance=TRUE)
```

actually I guess concordance is not useful to package vignettes; do you really need it?
